### PR TITLE
graphify files excluded

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+graphify-out/graph.json merge=graphify

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-graphify-out/graph.json merge=graphify

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,3 @@ docs/examples/stix2/bundles
 
 # graphify
 graphify-out
-.gitattributes

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ docs/examples/risklists/risklists
 docs/examples/stix2/bundles
 
 
+# graphify
+graphify-out

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ docs/examples/stix2/bundles
 
 # graphify
 graphify-out
+.gitattributes


### PR DESCRIPTION
## Add `graphify-out/` to `.gitignore`

Adds a single line to `.gitignore` so the `graphify-out/` folder is not tracked.

### Why
I'm using Graphify locally to map the codebase into a queryable knowledge graph while getting up to speed. It writes its output to `graphify-out/`, and that generated artifact shouldn't be committed to a public repo — both to keep the repo clean and to avoid publishing a structural map of the code. Ignoring it keeps the output entirely local.

### Scope
`.gitignore` only — no source, config, CI, or dependency changes.