### PR TITLE
add TypeAdapter and model validation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,4 @@
-# Developing for PSEngine
-
-In the guide below there is often the mention of "us" that means:
-
-- Ernest Bartosevic
-- Moise Medici
-
-# Development Process
+# Development Process for PSEngine
 
 ## Pre Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,368 @@
+# Developing for PSEngine
+
+In the guide below there is often the mention of "us" that means:
+
+- Ernest Bartosevic
+- Moise Medici
+
+# Development Process
+
+## Pre Requirements
+
+* The minimum python version specified in the `pyproject.toml`
+* Set environmental variable `RF_API_KEY` (PSEngine requirement), `RF_ASI_KEY` and `RF_SANDBOX_KEY` are also needed for ASI and Sandbox functionalities.
+* Read the [Internals](https://recordedfuture-professionalservices.github.io/psengine/latest/modules/internals/) page
+* A basic `pydantic` v2 knowledge (Some info in the Internals page)
+
+## Code Requirements
+
+To have your code merged there are some requirements your code must satisfy:
+
+* Doing `pydantic` validation and adhering to the `psengine` standards (more on this in the Code standards section)
+* Having properly documented public facing methods
+* Having a good level of unit testing
+* Having the public documentation written for the module added. If you are merging a feature, consider if the user needs to know about this feature, if yes add it to the public documentation
+* Having the CHANGELOG updated. The CHANGELOG should be explanatory of what the change fix/feature is about and in context of a fix, what is fixing and in which circumstances.
+* Having the ruff rules satisfied
+
+There is an expectation that you are going to fulfil this requirements but we will help on any of these steps. Just ask :)
+
+## Installation and Setup
+
+Create a remote branch in the Github UI.
+
+Download the repo:
+
+```
+git clone https://github.com/RecordedFuture-ProfessionalServices/psengine
+```
+
+Move to the repo folder `psengine`, move to your branch and pull your branch:
+
+```
+cd psengine
+git checkout new_feature
+git pull
+```
+
+Download `uv` if you don't have it already: <https://docs.astral.sh/uv/getting-started/installation/>.
+Run `uv sync` which will create a virtual environment with Python 3.11 and all the standard, test and docs related dependencies.
+
+A new environment with a different Python version can be created with `uv sync -p 3.13`. `uv` will download the interpreter if you don't have it already and install the dependencies.
+
+### Dependency Management
+
+All the dependencies are managed by `uv` via the `uv.lock` file. To add or remove a dependency use either `uv add` or `uv remove`:
+
+```
+uv add <depenedency>
+uv add <dependency> --group [docs | dev ]
+```
+
+More information: <https://docs.astral.sh/uv/concepts/projects/dependencies/#adding-dependencies>
+
+## Developing
+
+### Module Structure Explained
+
+All modules (there might be some rare exceptions) have the following structure:
+
+```
+psengine/new_feature
+├── __init__.py
+├── constants.py
+├── errors.py
+├── helpers.py
+├── models.py
+├── new_feature.py
+└── new_feature_mgr.py
+```
+
+File explanation:
+
+1. `__init__.py` → (Mandatory) expose the classes that are used by the enduser so the import can be done like
+
+    ```python
+    from psengine.analyst_note import AnalystNoteMgr
+    ```
+2. `constants.py` → (Optional) any static value that is needed inside one or more of your classes can be stored here. DO NOT store the endpoint url, this goes in `psengine/endpoints.py.`
+3. `errors.py` → (Optional) any custom exceptions you want to raise. It is optional but recommended to raise custom exceptions for a better user experience and communicate a clear error scenario.
+4. `helpers.py` → (Optional) any external function useful to the module but that do not is strictly related to the manager responsibilities. For example saving the attachment of a Analyst Note is a good candidate for this file.
+5. `models.py` → (Optional) any Pydantic models that are not exposed to the end user can be stored here.
+6. `new_feature.py` → (Mandatory) this file contains the ADT (abstract data type) and Pydantic models used by the user. (See Naming Convention for the difference in naming)
+7. `new_feature_mgr.py` → (Mandatory) this file contains the interactions between the ADT and Pydantic models agains the API.
+
+If any of the optional files is not used in your code, you can delete it.
+
+### Validators
+
+In `psengine.helpers.helpers.Validators` there are a few generic purpose validators:
+
+* `convert_str_to_list`: from a string it converts it to list like: `[string]`. Example `"moise"` becomes `["moise"]`.
+* `convert_relative_time`: converts a relative time like `8d` to ISO format date string.
+* `check_uhash_prefix`: from a string or a list of strings, prepend `uhash:` to all the strings if not present. Example `"moise"` becomes `"uhash:moise"`.
+
+This validators can be used as `AfterValidator` or `BeforeValidator` in any model for convenience. For example if a API expects a field with `uhash:abcd` we can add the `AfterValidator` of `check_uhash_prefix` so that the user doesn't need to remember to add the prefix when using psengine but the validator adds the prefix for us.
+
+Example usage:
+
+```python
+class MalwareReportIn(RFBaseModel):
+    """Validate data sent to the `/v1/reports` endpoint."""
+
+    query: str
+    sha256: str | None = None
+    start_date: Annotated[
+        str, BeforeValidator(Validators.convert_relative_time), AfterValidator(_split_time)
+    ]
+    end_date: Annotated[
+        str | None,
+        BeforeValidator(Validators.convert_relative_time),
+        AfterValidator(_split_time),
+    ]
+    my_enterprise: bool
+    limit: int = Field(ge=1, le=10)
+```
+
+### Code Standards
+
+This section explains which standards and conventions we are adhering to.
+
+#### Ruff
+
+`ruff` (<https://docs.astral.sh/ruff/>) helps us with the majority of the code standards, you can run `ruff` with `make lint` and `make format`.
+
+* `make format` will reformat your code and will always succeed unless there are syntax errors in your code
+* `make lint` will run `make format` and the ruff linting rules. It will return all the errors found that `ruff` was not able to fix on its own:
+
+    ```
+    ❯ make lint
+    psengine/classic_alerts/classic_alert.py:
+      109:9 D102 Missing docstring in public method
+      136:9 D102 Missing docstring in public method
+
+    psengine_cli/constants.py:
+      3:17 PTH118 `os.path.join()` should be replaced by `Path` with `/` operator
+      3:30 PTH120 `os.path.dirname()` should be replaced by `Path.parent`
+    ```
+
+Adding `noqa` is not allowed except for special cases.
+
+### Tests
+
+Use `pytest` to test your code. If you know nothing about `pytest` let us know, we can help you set up your tests structure.
+The standard `tests` folder structure is:
+
+```
+tests/new_feature
+├── conftest.py
+├── test_new_feature.py
+└── test_new_feature_mgr.py
+```
+
+File explanation:
+
+* `conftests.py` → store your fixtures in case they do not need to be used by other modules
+* `test_new_feature.py` → tests for your models and ADTs
+* `test_new_feature_mgr.py` → tests for your manager. If you have helpers functions, you can test them in this file or create a `test_helpers.py`, either ways is fine.
+
+#### Donts
+
+* Tests must not do live HTTP requests, use `mock`
+* Use VCR. As a public repo we need to hide some of the information that we expose to the public as they are Recorded Future proprietary. Use mock and obfuscate the mock. See the Mock section below.
+* Tests must not write in folders outside the `tests` dir. You can use the pytest fixture `tmp_path` if needed.
+* Flaky tests
+* Tests that are dependent on other tests, the Github Actions run tests in random orders.
+
+### Mocks
+
+Any mock file or data added as test, needs to be reviewed for sensitive data BEFORE any commit of such data.
+
+In `tests/conftest.py` there are a few fixture that help the usage of mocks:
+
+* `mock_request`: from a json file, it returns a `requests.Response` with content the content of the file
+* `make_response`: from a dict returns a `reqeusts.Response` object
+* `make_binary_response`: from binary returns a `reqeusts.Response` object
+* `make_csv_response`: from a csv file or a csv-like string it returns a `reqeusts.Response` object with the csv as attachment
+
+The way to use the above mockers is:
+
+```python
+def test_lookup(self, mgr, mock_request, mocker):
+    mock = mock_request(MOCK_DIR / 'note_tQHD_j.json')
+    mocker.patch.object(an_mgr.rf_client, 'request', return_value=mock)
+    note = an_mgr.lookup('tQHD_j')
+    assert isinstance(note, AnalystNote)
+```
+
+## Final Steps
+
+### Formatting
+
+Run a `make format` and `make lint` before running the Github actions and make sure there are no errors, else the GitHub actions will fail.
+
+### Docstring
+
+The docstring of public methods (example `search`), special methods (example `__str__`, `__init__`) are picked up and uploaded in <https://recordedfuture-professionalservices.github.io/psengine/latest/api/>. To make sure that the parsing is done properly some rules needs to be followed:
+
+1. The `Annotated[Doc]` should be used for parameters and returns of public facing methods.
+2. In public methods there should be a `Endpoints:` section to tell with endpoint is the function hitting. Example:
+
+    ```
+    Endpoint:
+        `/analystnote/search`
+    ```
+3. Code should be defined in the following way:
+
+    ````
+    Example:
+
+       ```python
+         <code>
+       ```
+    ````
+
+Please do not ignore any error from the Github action that publish the docs and if you are not sure how to fix them, let us know.
+
+There are some known warnings from `psengine/config/config.py` and `modules/_includes/examples_warning.md`. All the others must be reviewed.
+
+## Ready to merge?
+
+Once ready to merge, open a merge request on GitHub, and add any of us as reviewers.
+
+# Github Actions
+
+These are the Github Actions configured:
+
+| **Name** | **When Run** | **Mandatory in MR** | **Purpose** | **Fails If** |
+| --- | --- | --- | --- | --- |
+| `build_docs.yml` | If `doc_examples.yml` succeed. Runs when triggered by `docs_examples.yml`. | No | Run `mike` to build the documentation in the `gh-pages` repo. | There are unfixed errors in the documentation. |
+| `doc_examples.yml` | On every merge to `main`. Runs automatically. | No | Run all the examples in `docs/examples` | At least one example script fails. With the exception of the files added to the `KNOWN_FAILS` array. |
+| `format.yml` | Every commit after a MR is opened | Yes | Check that the code has been formatted with `ruff` and the rules specified in `ruff.toml` | Ruff formatting fails on at least one file. |
+| `import_checks.yml` | Every commit after a MR is opened | Yes | Check that in `psengine` directory there are no imports like `from psengine.x import y` we want to stick to relative imports. Example `from ..x import y`, due to issues in Artifactory. | There is at least one occurrence of a wrong import. |
+| `lint.yml` | Every commit after a MR is opened | Yes | Check that the code has been linted with `ruff` and the rules specified in `ruff.toml` | Ruff lint fails on at least one file. |
+| `typos.yml` | Every commit after a MR is opened | Yes | Check with `typos-cli` that there are not typos in `psengine`, `docs` and the `README.md` | There is at least one typo found by `typos-cli` |
+| `unittests.yml` | Every commit after a MR is opened | Yes | Check that there are no issues on all the supported versions of python. The tests results are written in the PR comment section and a link to the coverage file is attached. | The coverage falls below 94% in the overall project or at least one test in at least one python version fails. |
+| `workflow.yml` | On every merge where the `pyproject.toml` version is increased. Run automatically. If the tagging and release is ok it build and push a `.whl` file to PyPi. Warning: do NOT change the name of the workflow. If you have to, schedule it with Paul Fothergill, to change it in the PyPi UI first. | No | Create a new release package and tag it with the latest version. It checks first if the new package has a different version compared to the current latest tag. If no, the rest of the action is skipped. | The tag and release part fails if there are `git` issues in the process, or `pyproject.toml` is not found. The PyPi if it gets renamed, or something in the permissions on PyPi has changed. |
+
+There is a ruleset in Github that blocks from merging the pull request if not all the actions that run in the PR are not passing.
+
+A graphical representation of the runs from a pull request that gets merged into `main`:
+
+```mermaid
+flowchart TD
+    PR([Open PR]) --> Checks
+
+    subgraph Checks[Mandatory PR checks — every commit]
+        direction LR
+        F[format.yml]
+        L[lint.yml]
+        I[import_checks.yml]
+        T[typos.yml]
+        U[unittests.yml]
+    end
+
+    Checks -->|any fail| Blocked[Blocked — cannot merge]
+    Checks -->|all pass| Merge{{Merge to main}}
+
+    Merge --> Docs[doc_examples.yml]
+    Docs -->|success| Build[build_docs.yml<br/>publish to gh-pages]
+
+    Merge --> Ver{pyproject.toml<br/>version bumped?}
+    Ver -->|yes| Release[workflow.yml<br/>tag + release + push .whl to PyPi]
+    Ver -->|no| Done([Done])
+```
+
+# Documentation
+
+The documentation is build using `mkdocs` and `mike`. To test your documentation locally, do the following:
+
+```
+mkdocs serve
+```
+
+Alternatively you can run `mike serve` instead of `mkdocs serve` however I have been having issues in displaying the correct versions locally.
+
+You will be able to access the documentation on `localhost:8000` both if you are using `mkdocs` or `mike`.
+
+The `mkdocs` configuration and customisation is documented below:
+
+| **Category** | **Attribute** | **Explanation** |
+| --- | --- | --- |
+| `markdown_extensions` | `admonition` | Adds styled note/admonition blocks like tips, warnings, and examples. |
+| `markdown_extensions` | `attr_list` | Lets you add HTML attributes (like IDs or classes) directly in Markdown. |
+| `markdown_extensions` | `markdown_include.include` (base_path: docs) | Enables including external Markdown files, using `docs` as the base directory. |
+| `markdown_extensions` | `pymdownx.details` | Adds collapsible "details" blocks for expandable content sections. |
+| `markdown_extensions` | `pymdownx.highlight` (`anchor_linenums`, `linenums`, `guess_lang`) | Enhances code block highlighting with line numbers and stable language detection. |
+| `markdown_extensions` | `pymdownx.superfences` | Supports nested and custom fenced code blocks for advanced formatting. |
+| `markdown_extensions` | `pymdownx.inlinehilite` | Enables inline code highlighting using special syntax. |
+| `markdown_extensions` | `pymdownx.snippets (check_paths: true)` | Inserts external file snippets safely, verifying valid file paths. |
+| `markdown_extensions` | `toc (permalink: true)` | Generates a table of contents with clickable permalinks for each heading. |
+| `plugins` | `search` | Adds full-text search functionality to your documentation site. |
+| `plugins` | `mkdocstrings` | Automatically generates documentation from source code docstrings. |
+| `mkdocstrings.handlers.python.paths` | `["psengine"]` | Specifies the Python module(s) from which to extract documentation. |
+| `mkdocstrings.handlers.python.options.docstring_options.ignore_init_summary` | `true` | Excludes `__init__` summaries from class docstrings. |
+| `mkdocstrings.handlers.python.options.merge_init_into_class` | `true` | Merges constructor documentation into the class description. |
+| `mkdocstrings.handlers.python.options.extensions` | `griffe_typingdoc` | Improves type hint rendering using the `griffe_typingdoc` extension. |
+| `mkdocstrings.handlers.python.options.show_root_heading` | `true` | Displays a heading for the top-level module or class. |
+| `mkdocstrings.handlers.python.options.show_if_no_docstring` | `true` | Shows entries even when no docstring is present. |
+| `mkdocstrings.handlers.python.options.show_signature_annotations` | `true` | Displays type annotations in function/method signatures. |
+| `mkdocstrings.handlers.python.options.inherited_members` | `true` | Includes members inherited from parent classes. |
+| `mkdocstrings.handlers.python.options.separate_signature` | `true` | Places function signatures on their own lines for readability. |
+| `mkdocstrings.handlers.python.options.unwrap_annotated` | `true` | Removes `Annotated[]` wrappers from type hints for cleaner output. |
+| `mkdocstrings.handlers.python.options.docstring_section_style` | `spacy` | Formats docstring sections in a compact, spaCy-style layout. |
+| `mkdocstrings.handlers.python.options.signature_crossrefs` | `true` | Turns type names in signatures into clickable cross-references. |
+| `mkdocstrings.handlers.python.options.show_symbol_type_heading` | `true` | Displays headings for symbol types (like Classes, Functions, etc.). |
+| `mkdocstrings.handlers.python.options.show_symbol_type_toc` | `true` | Adds symbol type categories to the table of contents. |
+
+The files that are picked up during build are all defined in the `nav` section of the `mkdocs.yml` file. The `docs/examples` directory is excluded.
+
+The files under `docs/modules` are standard markdown files, while those under `docs/api` are markdown with a specific syntax of mkdocs. For example:
+
+```
+::: psengine.enrich.lookup_mgr.LookupMgr
+    options:
+        members:
+            - lookup
+            - lookup_bulk
+```
+
+The first line is making `mkdocs` to import `psengine.enrich.lookup_mgr.LookupMgr`.
+
+By default `mkdocs` would document all the public methods and the special methods. However, from the `options.members` list we are only specifying the `lookup` and `lookup_bulk` methods. This is done to avoid documenting the `__init__` which is already documented at the top of the page.
+
+The same can be done for variables only:
+
+```
+::: psengine.enrich.constants
+    options:
+       members:
+           - SOAR_POST_ROWS
+           - ALLOWED_ENTITIES
+           - ENTITY_FIELDS
+           - MALWARE_FIELDS
+```
+
+This is importing from `constants` only the variables that we think make sense to show the users.
+
+If more than one module has to be documented in the same file, that can be done like this:
+
+```
+::: psengine.enrich.models.lookup
+::: psengine.enrich.models.base_enriched_entity
+```
+
+### Documentation Version
+
+The version of the documentation is managed by `mike`:
+
+```
+extra:
+  version:
+    provider: mike
+```
+
+Note that when developing locally, if you run the `mkdocs serve` command to see your changes, the version dropdown will not be shown.
+`mike` is then executed in the Github Action.
+
+With the current configuration, all the changes in documentation in patch releases are written in the minor release documentation. So the documentation for 2.3.1, 2.3.2, 2.3.3 etc are all in 2.3 without distinction. That make sense if we continue following the semver standard and keep the CHANGELOG up to date.

--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ PSEngine has been made public from our internal version 2.0.4. Previous versions
 
 The documentation arrived at version 2.1.1. Older versions are not explicitly documented and changes can be found in the [Release History](./CHANGELOG.md) section.
 
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, code standards, testing conventions, and the CI workflow.
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## v2.12.0 - 2026-08-28
+
+### Added
+
+- Improved error handling for bulk actions. Now they are reporting the index and entity that is failing.
+
 ## v2.11.0 - 2026-08-20
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 
-- Improved error handling for bulk actions. Now they are reporting the index and entity that is failing.
+- Improved error handling for bulk actions in Python 3.11+. Now they are reporting the index and entity that is failing.
 
 ## v2.11.0 - 2026-08-20
 

--- a/docs/api/helpers/validation.md
+++ b/docs/api/helpers/validation.md
@@ -1,0 +1,4 @@
+::: psengine.helpers.validation
+    options:
+        members:
+            - validate_list

--- a/docs/api/risk_rules/constants.md
+++ b/docs/api/risk_rules/constants.md
@@ -1,1 +1,0 @@
-::: psengine.risk_rules.constants

--- a/docs/modules/risk_rules.md
+++ b/docs/modules/risk_rules.md
@@ -19,7 +19,7 @@ In this example we are fetching the domain's risk rules and filtering them based
 The `RiskRule` model implements ordering by criticality (highest first), which makes it easy to focus on the most severe rules.
 
 ```python
---8<-- "docs/examples/risk_rules/example_2.py"
+--8<-- "docs/examples/risk_rules/example_1.py"
 ```
 
 The output will be:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,7 @@ nav:
           - OSHelpers: api/helpers/os_helpers.md
           - TimeHelpers: api/helpers/time_helpers.md
           - Validators: api/helpers/validators.md
+          - Validation: api/helpers/validation.md
           - Misc: api/helpers/commons.md
       - Identity:
           - Manager: api/identity/identity_mgr.md

--- a/psengine/analyst_notes/note_mgr.py
+++ b/psengine/analyst_notes/note_mgr.py
@@ -28,7 +28,7 @@ from ..endpoints import (
     EP_ANALYST_NOTE_PUBLISH,
     EP_ANALYST_NOTE_SEARCH,
 )
-from ..helpers import debug_call
+from ..helpers import debug_call, validate_list
 from ..helpers.helpers import connection_exceptions
 from ..rf_client import RFClient
 from .constants import NOTES_PER_PAGE
@@ -358,4 +358,4 @@ class AnalystNoteMgr:
             max_results=max_results,
         )
 
-        return [AnalystNote.model_validate(d) for d in response]
+        return validate_list(AnalystNote, response, id_path='id', log=self.log)

--- a/psengine/enrich/soar_mgr.py
+++ b/psengine/enrich/soar_mgr.py
@@ -159,6 +159,4 @@ class SoarMgr:
             'results'
         ]
         contents = validate_list(SOAREnrichedEntity, res, id_path='entity.name', log=self.log)
-        return [
-            SOAREnrichOut(entity=c.entity.name, is_enriched=True, content=c) for c in contents
-        ]
+        return [SOAREnrichOut(entity=c.entity.name, is_enriched=True, content=c) for c in contents]

--- a/psengine/enrich/soar_mgr.py
+++ b/psengine/enrich/soar_mgr.py
@@ -19,7 +19,7 @@ from pydantic import validate_call
 from typing_extensions import Doc
 
 from ..endpoints import EP_SOAR_ENRICHMENT
-from ..helpers import MultiThreadingHelper, connection_exceptions, debug_call
+from ..helpers import MultiThreadingHelper, connection_exceptions, debug_call, validate_list
 from ..rf_client import RFClient
 from .constants import SOAR_POST_ROWS
 from .errors import EnrichmentSoarError
@@ -158,11 +158,7 @@ class SoarMgr:
         res = self.rf_client.request('post', EP_SOAR_ENRICHMENT, data=data.json()).json()['data'][
             'results'
         ]
-        result = []
-
-        for d in res:
-            content = SOAREnrichedEntity.model_validate(d)
-            entity = content.entity.name
-            result.append(SOAREnrichOut(entity=entity, is_enriched=True, content=content))
-
-        return result
+        contents = validate_list(SOAREnrichedEntity, res, id_path='entity.name', log=self.log)
+        return [
+            SOAREnrichOut(entity=c.entity.name, is_enriched=True, content=c) for c in contents
+        ]

--- a/psengine/entity_lists/entity_list.py
+++ b/psengine/entity_lists/entity_list.py
@@ -24,7 +24,7 @@ from ..common_models import IdNameType, RFBaseModel
 from ..constants import TIMESTAMP_STR
 from ..endpoints import EP_LIST, EP_LIST_ENTITIES_WITH_TAGS, EP_LIST_ENTITY_TAGS
 from ..entity_match import EntityMatchMgr, MatchApiError
-from ..helpers import debug_call
+from ..helpers import debug_call, validate_list
 from ..helpers.helpers import connection_exceptions
 from ..rf_client import RFClient
 from .constants import ADD_OP, ERROR_NAME, IS_READY_INCREMENT, REMOVE_OP, UNCHANGED_NAME
@@ -286,7 +286,7 @@ class EntityList(ListInfoOut):
         """
         url = EP_LIST + '/' + self.id_ + '/entities'
         response = self.rf_client.request('get', url)
-        return [ListEntity.model_validate(entity) for entity in response.json()]
+        return validate_list(ListEntity, response.json(), id_path='entity.name', log=self.log)
 
     @debug_call
     @connection_exceptions(ignore_status_code=[], exception_to_raise=ListApiError)
@@ -319,7 +319,9 @@ class EntityList(ListInfoOut):
         """
         url = EP_LIST_ENTITIES_WITH_TAGS.format(self.id_)
         response = self.rf_client.request('get', url)
-        return [ListEntityWithTags.model_validate(entity) for entity in response.json()]
+        return validate_list(
+            ListEntityWithTags, response.json(), id_path='entity.name', log=self.log
+        )
 
     @debug_call
     @validate_call

--- a/psengine/entity_match/entity_match_mgr.py
+++ b/psengine/entity_match/entity_match_mgr.py
@@ -21,7 +21,7 @@ from typing_extensions import Doc
 from ..common_models import IdNameType
 from ..constants import DEFAULT_LIMIT, DEFAULT_MAX_WORKERS
 from ..endpoints import EP_ENTITY_LOOKUP, EP_ENTITY_MATCH
-from ..helpers import MultiThreadingHelper, connection_exceptions, debug_call
+from ..helpers import MultiThreadingHelper, connection_exceptions, debug_call, validate_list
 from ..rf_client import RFClient
 from .entity_match import EntityLookup, EntityMatchIn, ResolvedEntity
 from .errors import MatchApiError
@@ -63,7 +63,7 @@ class EntityMatchMgr:
 
         request_body = EntityMatchIn(name=entity_name, type=entity_type, limit=limit)
         response = self.rf_client.request('post', EP_ENTITY_MATCH, data=request_body.json())
-        response = [IdNameType.model_validate(d) for d in response.json()]
+        response = validate_list(IdNameType, response.json(), id_path='name', log=self.log)
         return (
             list({ResolvedEntity(entity=d.name, is_found=bool(d.id_), content=d) for d in response})
             if response

--- a/psengine/helpers/__init__.py
+++ b/psengine/helpers/__init__.py
@@ -22,3 +22,4 @@ from .helpers import (
     debug_call,
     dump_models,
 )
+from .validation import validate_list

--- a/psengine/helpers/validation.py
+++ b/psengine/helpers/validation.py
@@ -1,0 +1,108 @@
+##################################### TERMS OF USE ###########################################
+# The following code is provided for demonstration purpose only, and should not be used      #
+# without independent verification. Recorded Future makes no representations or warranties,  #
+# express, implied, statutory, or otherwise, regarding any aspect of this code or of the     #
+# information it may retrieve, and provides it both strictly “as-is” and without assuming    #
+# responsibility for any information it may retrieve. Recorded Future shall not be liable    #
+# for, and you assume all risk of using, the foregoing. By using this code, Customer         #
+# represents that it is solely responsible for having all necessary licenses, permissions,   #
+# rights, and/or consents to connect to third party APIs, and that it is solely responsible  #
+# for having all necessary licenses, permissions, rights, and/or consents to any data        #
+# accessed from any third party API.                                                         #
+##############################################################################################
+
+import logging
+from collections.abc import Iterable
+from typing import Annotated, Any, TypeVar
+
+from pydantic import BaseModel, TypeAdapter, ValidationError
+from typing_extensions import Doc
+
+LOG = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+def validate_list(
+    model_cls: Annotated[type[T], Doc('Pydantic model each item should validate against.')],
+    items: Annotated[
+        Iterable[Any], Doc('Raw items to validate, typically dicts from an API response.')
+    ],
+    id_path: Annotated[
+        str | None,
+        Doc(
+            'Dotted path into each raw item used to build a friendly identifier for log lines '
+            "and exception notes, e.g. `'entity.name'`. If unresolvable for a given item, only "
+            'the index is reported.'
+        ),
+    ] = None,
+    log: Annotated[
+        logging.Logger | None,
+        Doc("Logger for the warnings. Defaults to this module's logger."),
+    ] = None,
+) -> Annotated[list[T], Doc('The list of validated `model_cls` instances.')]:
+    """Validate a list of dicts against `model_cls`.
+
+    Uses pydantic's `TypeAdapter` so a single validation pass collects all per-item errors with an
+    index in their `loc`.
+
+    Before re-raising, each failing item is (a) logged individually as a warning and (b) attached
+    to the exception via `add_note`, so the entity identifier shows up in the traceback too.
+
+    If `id_path` is provided, a human-readable identifier is extracted from the raw dict
+    (e.g. `entity.name`); otherwise only the index is reported.
+
+    Raises:
+        pydantic.ValidationError: If any item fails validation. Unchanged
+            from `[model_cls.model_validate(x) for x in items]`.
+    """
+    if not isinstance(items, list):
+        items = list(items)
+    try:
+        return TypeAdapter(list[model_cls]).validate_python(items)
+    except ValidationError as e:
+        for msg in _format_failures(e, items, id_path, model_cls):
+            (log or LOG).warning(msg)
+            e.add_note(msg)
+        raise
+
+
+def _format_failures(
+    exc: ValidationError,
+    items: list[Any],
+    id_path: str | None,
+    model_cls: type[BaseModel],
+) -> list[str]:
+    """Build one message per failing item, keyed by index and optional id."""
+    seen: set[int] = set()
+    messages: list[str] = []
+    for err in exc.errors():
+        loc = err.get('loc') or ()
+        if not loc or not isinstance(loc[0], int):
+            continue
+        idx = loc[0]
+        if idx in seen:
+            continue
+        seen.add(idx)
+
+        raw = items[idx] if 0 <= idx < len(items) else None
+        identifier = _resolve_id_path(raw, id_path) if id_path else None
+        id_hint = f' ({id_path}={identifier})' if identifier is not None else ''
+        field_path = '.'.join(str(p) for p in loc[1:]) or '<root>'
+        messages.append(
+            f'{model_cls.__name__} validation failed at index {idx}{id_hint}: '
+            f"field '{field_path}' {err.get('msg', '')}"
+        )
+    return messages
+
+
+def _resolve_id_path(item: Any, id_path: str) -> Any:
+    """Walk `id_path` (dot-separated) into `item`. Returns None on miss."""
+    value: Any = item
+    for part in id_path.split('.'):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+        if value is None:
+            return None
+    return value

--- a/psengine/helpers/validation.py
+++ b/psengine/helpers/validation.py
@@ -46,8 +46,10 @@ def validate_list(
     Uses pydantic's `TypeAdapter` so a single validation pass collects all per-item errors with an
     index in their `loc`.
 
-    Before re-raising, each failing item is (a) logged individually as a warning and (b) attached
-    to the exception via `add_note`, so the entity identifier shows up in the traceback too.
+    Before re-raising, each failing item is (a) logged individually as a warning and (b) on
+    Python 3.11+ attached to the exception via `add_note`, so the entity identifier shows up in
+    the traceback too. On Python 3.10 the note step is skipped since `BaseException.add_note`
+    is not available.
 
     If `id_path` is provided, a human-readable identifier is extracted from the raw dict
     (e.g. `entity.name`); otherwise only the index is reported.
@@ -63,7 +65,8 @@ def validate_list(
     except ValidationError as e:
         for msg in _format_failures(e, items, id_path, model_cls):
             (log or LOG).warning(msg)
-            e.add_note(msg)
+            if hasattr(e, 'add_note'):
+                e.add_note(msg)
         raise
 
 

--- a/psengine/identity/identity_mgr.py
+++ b/psengine/identity/identity_mgr.py
@@ -29,7 +29,7 @@ from ..endpoints import (
     EP_IDENTITY_IP_LOOKUP,
     EP_IDENTITY_PASSWORD_LOOKUP,
 )
-from ..helpers import TimeHelpers, connection_exceptions, debug_call
+from ..helpers import TimeHelpers, connection_exceptions, debug_call, validate_list
 from ..rf_client import RFClient
 from .constants import DETECTIONS_PER_PAGE, MAXIMUM_IDENTITIES
 from .errors import (
@@ -252,7 +252,7 @@ class IdentityMgr:
             results_path='identities',
             max_results=max_results or DEFAULT_LIMIT,
         )
-        resp = [LeakedIdentity.model_validate(identity) for identity in resp]
+        resp = validate_list(LeakedIdentity, resp, log=self.log)
         self.log.info(f'Returned {len(resp)} identities')
         return resp
 
@@ -321,7 +321,7 @@ class IdentityMgr:
         resp = self.rf_client.request('post', url=EP_IDENTITY_PASSWORD_LOOKUP, data=data).json()[
             'results'
         ]
-        resp = [PasswordLookup.model_validate(v) for v in resp]
+        resp = validate_list(PasswordLookup, resp, id_path='password.hash_prefix', log=self.log)
         self.log.info(f'Returned {len(resp)} passwords')
         return resp
 
@@ -436,7 +436,7 @@ class IdentityMgr:
             max_results=max_results or DEFAULT_LIMIT,
             results_path='identities',
         )
-        resp = [LeakedIdentity.model_validate(identity) for identity in resp]
+        resp = validate_list(LeakedIdentity, resp, log=self.log)
         self.log.info(f'Returned {len(resp)} identities')
         return resp
 
@@ -561,7 +561,7 @@ class IdentityMgr:
             max_results=max_results or DEFAULT_LIMIT,
             results_path='identities',
         )
-        resp = [LeakedIdentity.model_validate(identity) for identity in resp]
+        resp = validate_list(LeakedIdentity, resp, log=self.log)
         self.log.info(f'Returned {len(resp)} identities')
         return resp
 
@@ -663,7 +663,7 @@ class IdentityMgr:
             max_results=max_results or DEFAULT_LIMIT,
             results_path='identities',
         )
-        resp = [CredentialSearch.model_validate(d) for d in resp]
+        resp = validate_list(CredentialSearch, resp, id_path='login', log=self.log)
         self.log.info(f'Returned {len(resp)} credentials')
         return resp
 
@@ -707,7 +707,7 @@ class IdentityMgr:
         resp = self.rf_client.request('post', url=EP_IDENTITY_DUMP_SEARCH, data=payload).json()[
             'dumps'
         ]
-        resp = [DumpSearchOut.model_validate(d) for d in resp]
+        resp = validate_list(DumpSearchOut, resp, id_path='name', log=self.log)
         self.log.info(f'Returned {len(resp)} dump results')
         return resp
 

--- a/psengine/risk_history/risk_history_mgr.py
+++ b/psengine/risk_history/risk_history_mgr.py
@@ -18,7 +18,7 @@ from pydantic import validate_call
 from typing_extensions import Doc
 
 from ..endpoints import EP_RISK_HISTORY
-from ..helpers import debug_call
+from ..helpers import debug_call, validate_list
 from ..helpers.helpers import connection_exceptions
 from ..rf_client import RFClient
 from .errors import RiskHistoryError
@@ -57,4 +57,4 @@ class RiskHistoryMgr:
         data = RiskHistoryIn.model_validate({'entities': entities, 'from': from_, 'to': to})
         attrs = self.rf_client.request('post', EP_RISK_HISTORY, data=data.json()).json()['data']
 
-        return [RiskHistory.model_validate(attr) for attr in attrs]
+        return validate_list(RiskHistory, attrs, id_path='entity.id', log=self.log)

--- a/psengine/risk_rules/risk_rule_mgr.py
+++ b/psengine/risk_rules/risk_rule_mgr.py
@@ -18,7 +18,7 @@ from pydantic import validate_call
 from typing_extensions import Doc
 
 from ..endpoints import EP_RISK_RULES
-from ..helpers import debug_call
+from ..helpers import debug_call, validate_list
 from ..helpers.helpers import connection_exceptions
 from ..rf_client import RFClient
 from .errors import RiskRuleFetchError
@@ -60,4 +60,4 @@ class RiskRuleMgr:
         self.log.info(f'Fetching risk rules for entity type: {entity_type.value}')
         response = self.rf_client.request('get', url).json()
         results = response['data']['results']
-        return [RiskRule.model_validate(r) for r in results]
+        return validate_list(RiskRule, results, id_path='name', log=self.log)

--- a/psengine/threat_maps/threat_map_mgr.py
+++ b/psengine/threat_maps/threat_map_mgr.py
@@ -25,7 +25,7 @@ from ..endpoints import (
     EP_THREAT_MAP_ORG,
     EP_THREAT_MAPS_LIST,
 )
-from ..helpers import debug_call
+from ..helpers import debug_call, validate_list
 from ..helpers.helpers import connection_exceptions
 from ..rf_client import RFClient
 from .errors import (
@@ -73,7 +73,7 @@ class ThreatMapMgr:
             ThreatMapInfoError: If connection error occurs.
         """
         maps_response = self.rf_client.request(method='get', url=EP_THREAT_MAPS_LIST).json()['data']
-        return [ThreatMapInfo.model_validate(entry) for entry in maps_response]
+        return validate_list(ThreatMapInfo, maps_response, id_path='name', log=self.log)
 
     @debug_call
     @validate_call
@@ -94,7 +94,7 @@ class ThreatMapMgr:
         map_type = ThreatMapType(map_type)
         url = EP_CATEGORIES.format(map_type.category_slug)
         cat_response = self.rf_client.request(method='get', url=url).json()['data']
-        return [EntityCategory.model_validate(ent) for ent in cat_response]
+        return validate_list(EntityCategory, cat_response, id_path='id', log=self.log)
 
     @debug_call
     @validate_call
@@ -134,7 +134,7 @@ class ThreatMapMgr:
             offset_key='offset',
             max_results=max_results or DEFAULT_LIMIT,
         )
-        return [ThreatActorProfile.model_validate(ta) for ta in search_response]
+        return validate_list(ThreatActorProfile, search_response, id_path='id', log=self.log)
 
     @debug_call
     @validate_call

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "psengine"
-version = "2.11.0"
+version = "2.12.0"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10, <3.15"

--- a/scripts/run_doc_examples.sh
+++ b/scripts/run_doc_examples.sh
@@ -136,8 +136,14 @@ export -f run_once run_with_retry capture
 say "Scanning $EXAMPLES_DIR — jobs=$JOBS attempts=$MAX_ATTEMPTS retry_delay=${RETRY_DELAY}s"
 say "Per-attempt logs: $LOG_DIR"
 
-find "$EXAMPLES_DIR" -type f -name "*.py" -print0 \
+# malware_intel examples share Auto Sigma job quota per token — the backend
+# fails concurrent jobs straight to FAILED, so run them serially. Everything
+# else fans out to $JOBS workers as before.
+find "$EXAMPLES_DIR" -type f -name "*.py" -not -path "*/malware_intel/*" -print0 \
   | parallel -0 -j "$JOBS" capture {} || true
+
+find "$EXAMPLES_DIR/malware_intel" -type f -name "*.py" -print0 2>/dev/null \
+  | parallel -0 -j 1 capture {} || true
 
 if [[ -s "$FAIL_LIST_FILE" ]]; then
   sort -u "$FAIL_LIST_FILE" -o "$FAIL_LIST_FILE"

--- a/tests/analyst_notes/test_analyst_notes_mgr.py
+++ b/tests/analyst_notes/test_analyst_notes_mgr.py
@@ -7,8 +7,6 @@ from pydantic import ValidationError
 from requests import ConnectionError, ConnectTimeout, HTTPError, ReadTimeout  # noqa: A004
 from requests.models import Response
 
-from tests.conftest import validation_match
-
 from psengine.analyst_notes import (
     AnalystNote,
     AnalystNoteAttachmentError,
@@ -28,6 +26,7 @@ from psengine.endpoints import (
 )
 from psengine.errors import WriteFileError
 from tests.analyst_notes.constants import MOCK_DIR
+from tests.conftest import validation_match
 
 # tQHD_j - existing note without attachment
 # tPtLVw - existing note with PDF attachment

--- a/tests/analyst_notes/test_analyst_notes_mgr.py
+++ b/tests/analyst_notes/test_analyst_notes_mgr.py
@@ -7,6 +7,8 @@ from pydantic import ValidationError
 from requests import ConnectionError, ConnectTimeout, HTTPError, ReadTimeout  # noqa: A004
 from requests.models import Response
 
+from tests.conftest import validation_match
+
 from psengine.analyst_notes import (
     AnalystNote,
     AnalystNoteAttachmentError,
@@ -167,7 +169,7 @@ class Test_AnalystNotesMgr:
         del bad['source']
         payload = {'data': [good, bad], 'next_offset': None, 'counts': {'returned': 2}}
         mocker.patch.object(an_mgr.rf_client, 'request', return_value=make_response(payload))
-        with pytest.raises(ValidationError, match='id=broken-note-id'):
+        with pytest.raises(ValidationError, match=validation_match('id=broken-note-id')):
             an_mgr.search()
 
     def test_search_raises_SearchError_dueto_KeyError(self, an_mgr: AnalystNoteMgr, mocker):

--- a/tests/analyst_notes/test_analyst_notes_mgr.py
+++ b/tests/analyst_notes/test_analyst_notes_mgr.py
@@ -157,6 +157,19 @@ class Test_AnalystNotesMgr:
         assert all(isinstance(note, AnalystNote) for note in output)
         assert all(note.attributes.title for note in output)
 
+    def test_search_validation_error_names_entity(
+        self, an_mgr: AnalystNoteMgr, mocker, make_response
+    ):
+        with open(MOCK_DIR / 'test_search_ok_without_param_0.json') as f:
+            file_data = json.load(f)
+        good = file_data['data'][0]
+        bad = {**good, 'id': 'broken-note-id'}
+        del bad['source']
+        payload = {'data': [good, bad], 'next_offset': None, 'counts': {'returned': 2}}
+        mocker.patch.object(an_mgr.rf_client, 'request', return_value=make_response(payload))
+        with pytest.raises(ValidationError, match='id=broken-note-id'):
+            an_mgr.search()
+
     def test_search_raises_SearchError_dueto_KeyError(self, an_mgr: AnalystNoteMgr, mocker):
         mocker.patch.object(
             an_mgr.rf_client,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,16 @@ ROOT_DIR = dirname(abspath(__file__))
 sys.path.append(ROOT_DIR)
 
 
+def validation_match(note_pattern: str, py310_fallback: str = 'Field required') -> str:
+    """Return the regex to match a `ValidationError` message across Python versions.
+
+    `psengine.helpers.validation.validate_list` attaches an entity-identifying note to the raised
+    `ValidationError` via `BaseException.add_note`, which only exists on 3.11+. On 3.10 the note
+    isn't attached, so tests fall back to matching a substring of the underlying pydantic message.
+    """
+    return note_pattern if sys.version_info >= (3, 11) else py310_fallback
+
+
 @pytest.fixture
 def mock_request(mocker):
     """return a requests.Response object from a json file."""

--- a/tests/enrich/mocks/Test_Soar.test_soar_validation_error_at_index_3.json
+++ b/tests/enrich/mocks/Test_Soar.test_soar_validation_error_at_index_3.json
@@ -1,0 +1,449 @@
+{
+  "data": {
+    "results": [
+      {
+        "risk": {
+          "score": 0,
+          "level": 0.0,
+          "context": {
+            "phishing": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 3
+              }
+            },
+            "malware": {
+              "score": 0.0,
+              "rule": {
+                "maxCount": 3,
+                "count": 0
+              }
+            },
+            "public": {
+              "summary": [],
+              "score": 0.0,
+              "mostCriticalRule": "He looked inquisitively at his keyboard and wrote another sentence.",
+              "rule": {
+                "maxCount": 51
+              }
+            },
+            "c2": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 2
+              }
+            }
+          },
+          "rule": {
+            "summary": [],
+            "mostCritical": "In 1989 the building was heavily damaged by fire, but it has since been restored.",
+            "count": 0,
+            "maxCount": 52
+          }
+        },
+        "entity": {
+          "id": "ip:10.0.0.0",
+          "name": "10.0.0.0",
+          "type": "IpAddress"
+        }
+      },
+      {
+        "risk": {
+          "score": 0,
+          "level": 0.0,
+          "context": {
+            "phishing": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 3
+              }
+            },
+            "malware": {
+              "score": 0.0,
+              "rule": {
+                "maxCount": 3,
+                "count": 0
+              }
+            },
+            "public": {
+              "summary": [],
+              "score": 0.0,
+              "mostCriticalRule": "He looked inquisitively at his keyboard and wrote another sentence.",
+              "rule": {
+                "maxCount": 51
+              }
+            },
+            "c2": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 2
+              }
+            }
+          },
+          "rule": {
+            "summary": [],
+            "mostCritical": "In 1989 the building was heavily damaged by fire, but it has since been restored.",
+            "count": 0,
+            "maxCount": 52
+          }
+        },
+        "entity": {
+          "id": "ip:10.0.0.1",
+          "name": "10.0.0.1",
+          "type": "IpAddress"
+        }
+      },
+      {
+        "risk": {
+          "score": 0,
+          "level": 0.0,
+          "context": {
+            "phishing": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 3
+              }
+            },
+            "malware": {
+              "score": 0.0,
+              "rule": {
+                "maxCount": 3,
+                "count": 0
+              }
+            },
+            "public": {
+              "summary": [],
+              "score": 0.0,
+              "mostCriticalRule": "He looked inquisitively at his keyboard and wrote another sentence.",
+              "rule": {
+                "maxCount": 51
+              }
+            },
+            "c2": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 2
+              }
+            }
+          },
+          "rule": {
+            "summary": [],
+            "mostCritical": "In 1989 the building was heavily damaged by fire, but it has since been restored.",
+            "count": 0,
+            "maxCount": 52
+          }
+        },
+        "entity": {
+          "id": "ip:10.0.0.2",
+          "name": "10.0.0.2",
+          "type": "IpAddress"
+        }
+      },
+      {
+        "entity": {
+          "id": "ip:10.0.0.3",
+          "name": "10.0.0.3",
+          "type": "IpAddress"
+        }
+      },
+      {
+        "risk": {
+          "score": 0,
+          "level": 0.0,
+          "context": {
+            "phishing": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 3
+              }
+            },
+            "malware": {
+              "score": 0.0,
+              "rule": {
+                "maxCount": 3,
+                "count": 0
+              }
+            },
+            "public": {
+              "summary": [],
+              "score": 0.0,
+              "mostCriticalRule": "He looked inquisitively at his keyboard and wrote another sentence.",
+              "rule": {
+                "maxCount": 51
+              }
+            },
+            "c2": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 2
+              }
+            }
+          },
+          "rule": {
+            "summary": [],
+            "mostCritical": "In 1989 the building was heavily damaged by fire, but it has since been restored.",
+            "count": 0,
+            "maxCount": 52
+          }
+        },
+        "entity": {
+          "id": "ip:10.0.0.4",
+          "name": "10.0.0.4",
+          "type": "IpAddress"
+        }
+      },
+      {
+        "risk": {
+          "score": 0,
+          "level": 0.0,
+          "context": {
+            "phishing": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 3
+              }
+            },
+            "malware": {
+              "score": 0.0,
+              "rule": {
+                "maxCount": 3,
+                "count": 0
+              }
+            },
+            "public": {
+              "summary": [],
+              "score": 0.0,
+              "mostCriticalRule": "He looked inquisitively at his keyboard and wrote another sentence.",
+              "rule": {
+                "maxCount": 51
+              }
+            },
+            "c2": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 2
+              }
+            }
+          },
+          "rule": {
+            "summary": [],
+            "mostCritical": "In 1989 the building was heavily damaged by fire, but it has since been restored.",
+            "count": 0,
+            "maxCount": 52
+          }
+        },
+        "entity": {
+          "id": "ip:10.0.0.5",
+          "name": "10.0.0.5",
+          "type": "IpAddress"
+        }
+      },
+      {
+        "risk": {
+          "score": 0,
+          "level": 0.0,
+          "context": {
+            "phishing": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 3
+              }
+            },
+            "malware": {
+              "score": 0.0,
+              "rule": {
+                "maxCount": 3,
+                "count": 0
+              }
+            },
+            "public": {
+              "summary": [],
+              "score": 0.0,
+              "mostCriticalRule": "He looked inquisitively at his keyboard and wrote another sentence.",
+              "rule": {
+                "maxCount": 51
+              }
+            },
+            "c2": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 2
+              }
+            }
+          },
+          "rule": {
+            "summary": [],
+            "mostCritical": "In 1989 the building was heavily damaged by fire, but it has since been restored.",
+            "count": 0,
+            "maxCount": 52
+          }
+        },
+        "entity": {
+          "id": "ip:10.0.0.6",
+          "name": "10.0.0.6",
+          "type": "IpAddress"
+        }
+      },
+      {
+        "risk": {
+          "score": 0,
+          "level": 0.0,
+          "context": {
+            "phishing": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 3
+              }
+            },
+            "malware": {
+              "score": 0.0,
+              "rule": {
+                "maxCount": 3,
+                "count": 0
+              }
+            },
+            "public": {
+              "summary": [],
+              "score": 0.0,
+              "mostCriticalRule": "He looked inquisitively at his keyboard and wrote another sentence.",
+              "rule": {
+                "maxCount": 51
+              }
+            },
+            "c2": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 2
+              }
+            }
+          },
+          "rule": {
+            "summary": [],
+            "mostCritical": "In 1989 the building was heavily damaged by fire, but it has since been restored.",
+            "count": 0,
+            "maxCount": 52
+          }
+        },
+        "entity": {
+          "id": "ip:10.0.0.7",
+          "name": "10.0.0.7",
+          "type": "IpAddress"
+        }
+      },
+      {
+        "risk": {
+          "score": 0,
+          "level": 0.0,
+          "context": {
+            "phishing": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 3
+              }
+            },
+            "malware": {
+              "score": 0.0,
+              "rule": {
+                "maxCount": 3,
+                "count": 0
+              }
+            },
+            "public": {
+              "summary": [],
+              "score": 0.0,
+              "mostCriticalRule": "He looked inquisitively at his keyboard and wrote another sentence.",
+              "rule": {
+                "maxCount": 51
+              }
+            },
+            "c2": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 2
+              }
+            }
+          },
+          "rule": {
+            "summary": [],
+            "mostCritical": "In 1989 the building was heavily damaged by fire, but it has since been restored.",
+            "count": 0,
+            "maxCount": 52
+          }
+        },
+        "entity": {
+          "id": "ip:10.0.0.8",
+          "name": "10.0.0.8",
+          "type": "IpAddress"
+        }
+      },
+      {
+        "risk": {
+          "score": 0,
+          "level": 0.0,
+          "context": {
+            "phishing": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 3
+              }
+            },
+            "malware": {
+              "score": 0.0,
+              "rule": {
+                "maxCount": 3,
+                "count": 0
+              }
+            },
+            "public": {
+              "summary": [],
+              "score": 0.0,
+              "mostCriticalRule": "He looked inquisitively at his keyboard and wrote another sentence.",
+              "rule": {
+                "maxCount": 51
+              }
+            },
+            "c2": {
+              "score": 0.0,
+              "rule": {
+                "count": 0,
+                "maxCount": 2
+              }
+            }
+          },
+          "rule": {
+            "summary": [],
+            "mostCritical": "In 1989 the building was heavily damaged by fire, but it has since been restored.",
+            "count": 0,
+            "maxCount": 52
+          }
+        },
+        "entity": {
+          "id": "ip:10.0.0.9",
+          "name": "10.0.0.9",
+          "type": "IpAddress"
+        }
+      }
+    ]
+  },
+  "counts": {
+    "total": 10,
+    "returned": 10
+  }
+}

--- a/tests/enrich/test_soar_mgr.py
+++ b/tests/enrich/test_soar_mgr.py
@@ -3,6 +3,8 @@ from constants import COMPANY_DOM, DOMS, HASHS, IPS, MOCK_DIR, URLS
 from pydantic import ValidationError
 from requests import HTTPError
 
+from tests.conftest import validation_match
+
 from psengine.enrich import EnrichmentSoarError, SOAREnrichedEntity, SOAREnrichOut
 from psengine.enrich.constants import SOAR_POST_ROWS
 from psengine.enrich.soar_mgr import SoarMgr
@@ -102,7 +104,9 @@ class Test_SoarMgr:
             caplog.at_level('WARNING', logger='psengine.enrich.soar_mgr'),
             pytest.raises(
                 ValidationError,
-                match=r'.*validation failed at index 3 \(entity\.name\=10\.0\.0\.3\).*',
+                match=validation_match(
+                    r'.*validation failed at index 3 \(entity\.name\=10\.0\.0\.3\).*',
+                ),
             ),
         ):
             soar_mgr.soar(ip=[f'10.0.0.{i}' for i in range(10)])

--- a/tests/enrich/test_soar_mgr.py
+++ b/tests/enrich/test_soar_mgr.py
@@ -3,11 +3,10 @@ from constants import COMPANY_DOM, DOMS, HASHS, IPS, MOCK_DIR, URLS
 from pydantic import ValidationError
 from requests import HTTPError
 
-from tests.conftest import validation_match
-
 from psengine.enrich import EnrichmentSoarError, SOAREnrichedEntity, SOAREnrichOut
 from psengine.enrich.constants import SOAR_POST_ROWS
 from psengine.enrich.soar_mgr import SoarMgr
+from tests.conftest import validation_match
 
 
 class Test_SoarMgr:

--- a/tests/enrich/test_soar_mgr.py
+++ b/tests/enrich/test_soar_mgr.py
@@ -1,5 +1,6 @@
 import pytest
 from constants import COMPANY_DOM, DOMS, HASHS, IPS, MOCK_DIR, URLS
+from pydantic import ValidationError
 from requests import HTTPError
 
 from psengine.enrich import EnrichmentSoarError, SOAREnrichedEntity, SOAREnrichOut
@@ -90,3 +91,25 @@ class Test_SoarMgr:
     def test_soar_raise_ValueError(self, soar_mgr):
         with pytest.raises(ValueError, match='At least one parameter must be used'):
             soar_mgr.soar()
+
+    def test_soar_validation_error_logs_failing_entity(
+        self, soar_mgr, mocker, mock_request, caplog
+    ):
+        mock = mock_request(MOCK_DIR / 'Test_Soar.test_soar_validation_error_at_index_3.json')
+        mocker.patch.object(soar_mgr.rf_client, 'request', return_value=mock)
+
+        with (
+            caplog.at_level('WARNING', logger='psengine.enrich.soar_mgr'),
+            pytest.raises(
+                ValidationError,
+                match=r'.*validation failed at index 3 \(entity\.name\=10\.0\.0\.3\).*',
+            ),
+        ):
+            soar_mgr.soar(ip=[f'10.0.0.{i}' for i in range(10)])
+
+        warnings = [r for r in caplog.records if r.levelname == 'WARNING']
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert 'index 3' in msg
+        assert 'entity.name=10.0.0.3' in msg
+        assert 'SOAREnrichedEntity' in msg

--- a/tests/entity_lists/test_entity_list.py
+++ b/tests/entity_lists/test_entity_list.py
@@ -147,6 +147,44 @@ class Test_List:
 
         assert untagged.tags == []
 
+    def test_entities_validation_error_names_entity(
+        self, fresh_list: EntityList, mocker, make_response
+    ):
+        good = {
+            'entity': {'id': 'ip:8.8.8.8', 'type': 'IpAddress', 'name': '8.8.8.8'},
+            'status': 'ready',
+            'added': '2026-07-21T15:11:18.069Z',
+        }
+        bad = {
+            'entity': {'id': 'ip:1.1.1.1', 'type': 'IpAddress', 'name': 'broken-ip'},
+            'status': 'ready',
+        }
+        mocker.patch.object(
+            fresh_list.rf_client, 'request', return_value=make_response([good, bad, good])
+        )
+        with pytest.raises(ValidationError, match='entity.name=broken-ip'):
+            fresh_list.entities()
+
+    def test_entities_with_tags_validation_error_names_entity(
+        self, fresh_list: EntityList, mocker, make_response
+    ):
+        good = {
+            'entity': {'id': 'ip:8.8.8.8', 'type': 'IpAddress', 'name': '8.8.8.8'},
+            'status': 'ready',
+            'added': '2026-07-21T15:11:18.069Z',
+            'tags': [],
+        }
+        bad = {
+            'entity': {'id': 'ip:1.1.1.1', 'type': 'IpAddress', 'name': 'broken-ip'},
+            'status': 'ready',
+            'tags': [],
+        }
+        mocker.patch.object(
+            fresh_list.rf_client, 'request', return_value=make_response([good, bad, good])
+        )
+        with pytest.raises(ValidationError, match='entity.name=broken-ip'):
+            fresh_list.entities_with_tags()
+
     def test_entities_with_tags_no_tags_key(self, fresh_list: EntityList, mocker, make_response):
         mock = make_response(
             [

--- a/tests/entity_lists/test_entity_list.py
+++ b/tests/entity_lists/test_entity_list.py
@@ -4,7 +4,6 @@ from requests import Response
 from requests.models import HTTPError
 
 from psengine.endpoints import EP_LIST_ENTITIES_WITH_TAGS, EP_LIST_ENTITY_TAGS
-from tests.conftest import validation_match
 from psengine.entity_lists import (
     EntityList,
     EntityListMgr,
@@ -19,6 +18,7 @@ from psengine.entity_lists import (
     TagsUpdatedOperation,
 )
 from psengine.entity_match.errors import MatchApiError
+from tests.conftest import validation_match
 from tests.entity_lists.conftest import MOCK_DIR
 
 TEST_LIST = 'psengine-test-list-do-not-delete'

--- a/tests/entity_lists/test_entity_list.py
+++ b/tests/entity_lists/test_entity_list.py
@@ -4,6 +4,7 @@ from requests import Response
 from requests.models import HTTPError
 
 from psengine.endpoints import EP_LIST_ENTITIES_WITH_TAGS, EP_LIST_ENTITY_TAGS
+from tests.conftest import validation_match
 from psengine.entity_lists import (
     EntityList,
     EntityListMgr,
@@ -162,7 +163,7 @@ class Test_List:
         mocker.patch.object(
             fresh_list.rf_client, 'request', return_value=make_response([good, bad, good])
         )
-        with pytest.raises(ValidationError, match='entity.name=broken-ip'):
+        with pytest.raises(ValidationError, match=validation_match('entity.name=broken-ip')):
             fresh_list.entities()
 
     def test_entities_with_tags_validation_error_names_entity(
@@ -182,7 +183,7 @@ class Test_List:
         mocker.patch.object(
             fresh_list.rf_client, 'request', return_value=make_response([good, bad, good])
         )
-        with pytest.raises(ValidationError, match='entity.name=broken-ip'):
+        with pytest.raises(ValidationError, match=validation_match('entity.name=broken-ip')):
             fresh_list.entities_with_tags()
 
     def test_entities_with_tags_no_tags_key(self, fresh_list: EntityList, mocker, make_response):

--- a/tests/entity_match/test_entity_match_mgr.py
+++ b/tests/entity_match/test_entity_match_mgr.py
@@ -46,6 +46,17 @@ class Test_EntityMatchMgr:
         with pytest.raises(MatchApiError):
             match_mgr.match('8.8.8.8')
 
+    def test_match_validation_error_names_entity(
+        self, match_mgr: EntityMatchMgr, mocker, make_response
+    ):
+        good = {'id': 'ip:8.8.8.8', 'name': '8.8.8.8', 'type': 'IpAddress'}
+        bad = {'id': 'ip:1.1.1.1', 'name': 'broken-ip', 'type': ['not', 'a', 'string']}
+        mocker.patch.object(
+            match_mgr.rf_client, 'request', return_value=make_response([good, bad])
+        )
+        with pytest.raises(ValidationError, match='name=broken-ip'):
+            match_mgr.match('anything')
+
     def test_resolve_entity_ids(self, match_mgr: EntityMatchMgr, mocker, make_response):
         entitylist = [
             ('RedGolf', 'Organization'),

--- a/tests/entity_match/test_entity_match_mgr.py
+++ b/tests/entity_match/test_entity_match_mgr.py
@@ -51,9 +51,7 @@ class Test_EntityMatchMgr:
     ):
         good = {'id': 'ip:8.8.8.8', 'name': '8.8.8.8', 'type': 'IpAddress'}
         bad = {'id': 'ip:1.1.1.1', 'name': 'broken-ip', 'type': ['not', 'a', 'string']}
-        mocker.patch.object(
-            match_mgr.rf_client, 'request', return_value=make_response([good, bad])
-        )
+        mocker.patch.object(match_mgr.rf_client, 'request', return_value=make_response([good, bad]))
         with pytest.raises(ValidationError, match='name=broken-ip'):
             match_mgr.match('anything')
 

--- a/tests/entity_match/test_entity_match_mgr.py
+++ b/tests/entity_match/test_entity_match_mgr.py
@@ -2,6 +2,8 @@ from collections import Counter
 
 import pytest
 from pydantic import ValidationError
+
+from tests.conftest import validation_match
 from requests import HTTPError
 
 from psengine.common_models import IdNameType
@@ -52,7 +54,7 @@ class Test_EntityMatchMgr:
         good = {'id': 'ip:8.8.8.8', 'name': '8.8.8.8', 'type': 'IpAddress'}
         bad = {'id': 'ip:1.1.1.1', 'name': 'broken-ip', 'type': ['not', 'a', 'string']}
         mocker.patch.object(match_mgr.rf_client, 'request', return_value=make_response([good, bad]))
-        with pytest.raises(ValidationError, match='name=broken-ip'):
+        with pytest.raises(ValidationError, match=validation_match('name=broken-ip', 'string_type')):
             match_mgr.match('anything')
 
     def test_resolve_entity_ids(self, match_mgr: EntityMatchMgr, mocker, make_response):

--- a/tests/entity_match/test_entity_match_mgr.py
+++ b/tests/entity_match/test_entity_match_mgr.py
@@ -2,8 +2,6 @@ from collections import Counter
 
 import pytest
 from pydantic import ValidationError
-
-from tests.conftest import validation_match
 from requests import HTTPError
 
 from psengine.common_models import IdNameType
@@ -13,6 +11,7 @@ from psengine.entity_match import (
     ResolvedEntity,
 )
 from psengine.entity_match.entity_match import EntityLookup
+from tests.conftest import validation_match
 
 
 class Test_EntityMatchMgr:
@@ -54,7 +53,9 @@ class Test_EntityMatchMgr:
         good = {'id': 'ip:8.8.8.8', 'name': '8.8.8.8', 'type': 'IpAddress'}
         bad = {'id': 'ip:1.1.1.1', 'name': 'broken-ip', 'type': ['not', 'a', 'string']}
         mocker.patch.object(match_mgr.rf_client, 'request', return_value=make_response([good, bad]))
-        with pytest.raises(ValidationError, match=validation_match('name=broken-ip', 'string_type')):
+        with pytest.raises(
+            ValidationError, match=validation_match('name=broken-ip', 'string_type')
+        ):
             match_mgr.match('anything')
 
     def test_resolve_entity_ids(self, match_mgr: EntityMatchMgr, mocker, make_response):

--- a/tests/identity/test_identity_mgr.py
+++ b/tests/identity/test_identity_mgr.py
@@ -10,6 +10,7 @@ from data_for_tests import (
     HOSTNAME_LOOKUP_FILTER,
     IP_LOOKUP_FILTER,
 )
+from pydantic import ValidationError
 from requests.models import HTTPError
 
 from psengine.identity import IdentityMgr
@@ -311,6 +312,66 @@ class Test_IdentityMgr:
     def test_search_dump_raises_IdentitySearchError(self, identity_mgr: IdentityMgr, mocker):
         mocker.patch.object(identity_mgr.rf_client, 'request', side_effect=HTTPError)
         with pytest.raises(IdentitySearchError):
+            identity_mgr.search_dump(names='moise')
+
+    def test_lookup_hostname_validation_error_names_entity(
+        self, identity_mgr: IdentityMgr, mocker, make_response
+    ):
+        good = {'identity': {'subjects': ['ok@example.com']}, 'count': 1, 'credentials': []}
+        bad = {'identity': {'subjects': ['broken@example.com']}, 'credentials': []}
+        mocker.patch.object(
+            identity_mgr.rf_client,
+            'request',
+            return_value=make_response(
+                {'identities': [good, bad], 'count': 2, 'next_offset': None}
+            ),
+        )
+        with pytest.raises(ValidationError, match=r'LeakedIdentity validation failed at index 1'):
+            identity_mgr.lookup_hostname(hostname='Test')
+
+    def test_lookup_password_validation_error_names_entity(
+        self, identity_mgr: IdentityMgr, mocker, make_response
+    ):
+        good = {
+            'password': {'algorithm': 'SHA256', 'hash_prefix': 'okpref'},
+            'exposure_status': 'Common',
+        }
+        bad = {'password': {'algorithm': 'SHA256', 'hash_prefix': 'brokenpref'}}
+        mocker.patch.object(
+            identity_mgr.rf_client, 'request', return_value=make_response({'results': [good, bad]})
+        )
+        with pytest.raises(ValidationError, match='password.hash_prefix=brokenpref'):
+            identity_mgr.lookup_password(hash_prefix='abc', algorithm='sha256')
+
+    def test_search_credentials_validation_error_names_entity(
+        self, identity_mgr: IdentityMgr, mocker, make_response
+    ):
+        good = {'login': 'ok-login', 'domain': 'example.com'}
+        bad = {'login': 'broken-login'}
+        mocker.patch.object(
+            identity_mgr.rf_client,
+            'request',
+            return_value=make_response(
+                {'identities': [good, bad], 'count': 2, 'next_offset': None}
+            ),
+        )
+        with pytest.raises(ValidationError, match='login=broken-login'):
+            identity_mgr.search_credentials(domains='example.com')
+
+    def test_search_dump_validation_error_names_entity(
+        self, identity_mgr: IdentityMgr, mocker, make_response
+    ):
+        good = {
+            'name': 'good-dump',
+            'source': 'src',
+            'description': 'd',
+            'downloaded': '2024-01-01T00:00:00Z',
+        }
+        bad = {'name': 'broken-dump'}
+        mocker.patch.object(
+            identity_mgr.rf_client, 'request', return_value=make_response({'dumps': [good, bad]})
+        )
+        with pytest.raises(ValidationError, match='name=broken-dump'):
             identity_mgr.search_dump(names='moise')
 
     def test_incident_report_with_details(self, identity_mgr: IdentityMgr, mocker, mock_request):

--- a/tests/identity/test_identity_mgr.py
+++ b/tests/identity/test_identity_mgr.py
@@ -13,8 +13,6 @@ from data_for_tests import (
 from pydantic import ValidationError
 from requests.models import HTTPError
 
-from tests.conftest import validation_match
-
 from psengine.identity import IdentityMgr
 from psengine.identity.errors import DetectionsFetchError, IdentityLookupError, IdentitySearchError
 from psengine.identity.identity import (
@@ -28,6 +26,7 @@ from psengine.identity.models.incident_report import (
     IncidentReportCredentials,
     IncidentReportDetails,
 )
+from tests.conftest import validation_match
 from tests.identity.conftest import MOCK_DIR
 
 
@@ -345,7 +344,9 @@ class Test_IdentityMgr:
         mocker.patch.object(
             identity_mgr.rf_client, 'request', return_value=make_response({'results': [good, bad]})
         )
-        with pytest.raises(ValidationError, match=validation_match('password.hash_prefix=brokenpref')):
+        with pytest.raises(
+            ValidationError, match=validation_match('password.hash_prefix=brokenpref')
+        ):
             identity_mgr.lookup_password(hash_prefix='abc', algorithm='sha256')
 
     def test_search_credentials_validation_error_names_entity(

--- a/tests/identity/test_identity_mgr.py
+++ b/tests/identity/test_identity_mgr.py
@@ -13,6 +13,8 @@ from data_for_tests import (
 from pydantic import ValidationError
 from requests.models import HTTPError
 
+from tests.conftest import validation_match
+
 from psengine.identity import IdentityMgr
 from psengine.identity.errors import DetectionsFetchError, IdentityLookupError, IdentitySearchError
 from psengine.identity.identity import (
@@ -326,7 +328,10 @@ class Test_IdentityMgr:
                 {'identities': [good, bad], 'count': 2, 'next_offset': None}
             ),
         )
-        with pytest.raises(ValidationError, match=r'LeakedIdentity validation failed at index 1'):
+        with pytest.raises(
+            ValidationError,
+            match=validation_match(r'LeakedIdentity validation failed at index 1'),
+        ):
             identity_mgr.lookup_hostname(hostname='Test')
 
     def test_lookup_password_validation_error_names_entity(
@@ -340,7 +345,7 @@ class Test_IdentityMgr:
         mocker.patch.object(
             identity_mgr.rf_client, 'request', return_value=make_response({'results': [good, bad]})
         )
-        with pytest.raises(ValidationError, match='password.hash_prefix=brokenpref'):
+        with pytest.raises(ValidationError, match=validation_match('password.hash_prefix=brokenpref')):
             identity_mgr.lookup_password(hash_prefix='abc', algorithm='sha256')
 
     def test_search_credentials_validation_error_names_entity(
@@ -355,7 +360,7 @@ class Test_IdentityMgr:
                 {'identities': [good, bad], 'count': 2, 'next_offset': None}
             ),
         )
-        with pytest.raises(ValidationError, match='login=broken-login'):
+        with pytest.raises(ValidationError, match=validation_match('login=broken-login')):
             identity_mgr.search_credentials(domains='example.com')
 
     def test_search_dump_validation_error_names_entity(
@@ -371,7 +376,7 @@ class Test_IdentityMgr:
         mocker.patch.object(
             identity_mgr.rf_client, 'request', return_value=make_response({'dumps': [good, bad]})
         )
-        with pytest.raises(ValidationError, match='name=broken-dump'):
+        with pytest.raises(ValidationError, match=validation_match('name=broken-dump')):
             identity_mgr.search_dump(names='moise')
 
     def test_incident_report_with_details(self, identity_mgr: IdentityMgr, mocker, mock_request):

--- a/tests/risk_history/test_risk_history_mgr.py
+++ b/tests/risk_history/test_risk_history_mgr.py
@@ -4,10 +4,9 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from tests.conftest import validation_match
-
 from psengine.risk_history.models import RiskHistory
 from psengine.risk_history.risk_history_mgr import RiskHistoryMgr
+from tests.conftest import validation_match
 
 MOCK_DIR = Path(__file__).parent / 'mocks'
 
@@ -79,5 +78,7 @@ class Test_RiskHistoryMgr:
         mocker.patch.object(
             riskhistory_mgr.rf_client, 'request', return_value=make_response({'data': [good, bad]})
         )
-        with pytest.raises(ValidationError, match=validation_match('entity.id=broken-id', 'string_type')):
+        with pytest.raises(
+            ValidationError, match=validation_match('entity.id=broken-id', 'string_type')
+        ):
             riskhistory_mgr.search(entities='gVd1R')

--- a/tests/risk_history/test_risk_history_mgr.py
+++ b/tests/risk_history/test_risk_history_mgr.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from tests.conftest import validation_match
+
 from psengine.risk_history.models import RiskHistory
 from psengine.risk_history.risk_history_mgr import RiskHistoryMgr
 
@@ -77,5 +79,5 @@ class Test_RiskHistoryMgr:
         mocker.patch.object(
             riskhistory_mgr.rf_client, 'request', return_value=make_response({'data': [good, bad]})
         )
-        with pytest.raises(ValidationError, match='entity.id=broken-id'):
+        with pytest.raises(ValidationError, match=validation_match('entity.id=broken-id', 'string_type')):
             riskhistory_mgr.search(entities='gVd1R')

--- a/tests/risk_history/test_risk_history_mgr.py
+++ b/tests/risk_history/test_risk_history_mgr.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 from pathlib import Path
 
+import pytest
+from pydantic import ValidationError
+
 from psengine.risk_history.models import RiskHistory
 from psengine.risk_history.risk_history_mgr import RiskHistoryMgr
 
@@ -55,3 +58,24 @@ class Test_RiskHistoryMgr:
             == 'Entity Red Hat Enterprise Linux: Risk Score Changes: 6, Risk Rule Changes: 184'
         )
         assert str(reports[1]) == 'Entity Sudo: Risk Score Changes: 5, Risk Rule Changes: 67'
+
+    def test_risk_history_validation_error_names_entity(
+        self, riskhistory_mgr: RiskHistoryMgr, mocker, make_response
+    ):
+        good = {
+            'entity': {'id': 'gVd1R', 'provided_id': 'gVd1R', 'type': 'Product', 'name': 'Sudo'},
+            'scores': [],
+            'levels': [],
+            'risk_rules': [],
+        }
+        bad = {
+            'entity': {'id': 'broken-id', 'provided_id': 'broken-id', 'type': 42, 'name': 'Nope'},
+            'scores': [],
+            'levels': [],
+            'risk_rules': [],
+        }
+        mocker.patch.object(
+            riskhistory_mgr.rf_client, 'request', return_value=make_response({'data': [good, bad]})
+        )
+        with pytest.raises(ValidationError, match='entity.id=broken-id'):
+            riskhistory_mgr.search(entities='gVd1R')

--- a/tests/risk_rules/test_risk_rule_mgr.py
+++ b/tests/risk_rules/test_risk_rule_mgr.py
@@ -7,6 +7,7 @@ from requests.models import Response
 
 from psengine.endpoints import EP_RISK_RULES
 from psengine.risk_rules import RiskRule, RiskRuleEntityType, RiskRuleFetchError, RiskRuleMgr
+from tests.conftest import validation_match
 from tests.risk_rules.constants import MOCK_DIR
 
 ENTITY_TYPES = ['ip', 'domain', 'hash', 'vulnerability', 'url']
@@ -70,7 +71,7 @@ class Test_RiskRuleMgr:
         del bad['criticality']
         payload = {'data': {'results': [good, bad, good]}}
         mocker.patch.object(rr_mgr.rf_client, 'request', return_value=make_response(payload))
-        with pytest.raises(ValidationError, match='name=brokenRule'):
+        with pytest.raises(ValidationError, match=validation_match('name=brokenRule')):
             rr_mgr.fetch(RiskRuleEntityType.IP)
 
     def test_fetch_risk_rule_unwraps_data_results(self, rr_mgr: RiskRuleMgr, make_response, mocker):

--- a/tests/risk_rules/test_risk_rule_mgr.py
+++ b/tests/risk_rules/test_risk_rule_mgr.py
@@ -54,6 +54,25 @@ class Test_RiskRuleMgr:
         with pytest.raises(RiskRuleFetchError):
             rr_mgr.fetch(RiskRuleEntityType.IP)
 
+    def test_fetch_risk_rule_validation_error_names_entity(
+        self, rr_mgr: RiskRuleMgr, make_response, mocker
+    ):
+        good = {
+            'name': 'goodRule',
+            'description': 'ok',
+            'criticality': 3,
+            'criticalityLabel': 'Malicious',
+            'count': 1,
+            'categories': [],
+            'relatedEntities': [],
+        }
+        bad = {**good, 'name': 'brokenRule'}
+        del bad['criticality']
+        payload = {'data': {'results': [good, bad, good]}}
+        mocker.patch.object(rr_mgr.rf_client, 'request', return_value=make_response(payload))
+        with pytest.raises(ValidationError, match='name=brokenRule'):
+            rr_mgr.fetch(RiskRuleEntityType.IP)
+
     def test_fetch_risk_rule_unwraps_data_results(self, rr_mgr: RiskRuleMgr, make_response, mocker):
         payload = {
             'data': {

--- a/tests/threat_maps/test_threat_map_mgr.py
+++ b/tests/threat_maps/test_threat_map_mgr.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from pydantic import ValidationError
 
 from psengine.threat_maps import (
     EntityCategory,
@@ -68,6 +69,53 @@ class Test_ThreatMapMgr:
         actors = threat_map_mgr.search_threat_actor(name=name, max_results=max_results)
         actor = actors[0]
         assert isinstance(actor, ThreatActorProfile)
+
+    def test_fetch_available_maps_validation_error_names_entity(
+        self, threat_map_mgr: ThreatMapMgr, mocker, make_response
+    ):
+        good = {
+            'name': 'goodMap',
+            'type': 'actors',
+            'organization': {'id': 'org:1', 'name': 'RF'},
+            'url': 'https://x',
+        }
+        bad = {**good, 'name': 'brokenMap'}
+        del bad['organization']
+        mocker.patch.object(
+            threat_map_mgr.rf_client, 'request', return_value=make_response({'data': [good, bad]})
+        )
+        with pytest.raises(ValidationError, match='name=brokenMap'):
+            threat_map_mgr.fetch_available_maps()
+
+    def test_fetch_entity_categories_validation_error_names_entity(
+        self, threat_map_mgr: ThreatMapMgr, mocker, make_response
+    ):
+        with open(MOCK_DIR / 'test_fetch_categories.json') as f:
+            file_data = json.load(f)
+        good = file_data['data'][0]
+        bad = {**good, 'id': 'broken-cat-id'}
+        del bad['attributes']
+        mocker.patch.object(
+            threat_map_mgr.rf_client, 'request', return_value=make_response({'data': [good, bad]})
+        )
+        with pytest.raises(ValidationError, match='id=broken-cat-id'):
+            threat_map_mgr.fetch_entity_categories(map_type='actors')
+
+    def test_search_threat_actor_validation_error_names_entity(
+        self, threat_map_mgr: ThreatMapMgr, mocker
+    ):
+        with open(MOCK_DIR / 'test_search_threat_actors.json') as f:
+            file_data = json.load(f)
+        good = file_data['data'][0]
+        bad = {**good, 'id': 'broken-actor-id'}
+        del bad['attributes']
+        mocker.patch.object(
+            threat_map_mgr.rf_client,
+            'request_paged',
+            side_effect=lambda *args, **kwargs: iter([good, bad]),  # noqa: ARG005
+        )
+        with pytest.raises(ValidationError, match='id=broken-actor-id'):
+            threat_map_mgr.search_threat_actor(name='actor')
 
     @pytest.mark.parametrize(
         'map_type',

--- a/tests/threat_maps/test_threat_map_mgr.py
+++ b/tests/threat_maps/test_threat_map_mgr.py
@@ -10,6 +10,7 @@ from psengine.threat_maps import (
     ThreatMapInfo,
     ThreatMapMgr,
 )
+from tests.conftest import validation_match
 from tests.threat_maps.conftest import MOCK_DIR
 
 
@@ -84,7 +85,7 @@ class Test_ThreatMapMgr:
         mocker.patch.object(
             threat_map_mgr.rf_client, 'request', return_value=make_response({'data': [good, bad]})
         )
-        with pytest.raises(ValidationError, match='name=brokenMap'):
+        with pytest.raises(ValidationError, match=validation_match('name=brokenMap')):
             threat_map_mgr.fetch_available_maps()
 
     def test_fetch_entity_categories_validation_error_names_entity(
@@ -98,7 +99,7 @@ class Test_ThreatMapMgr:
         mocker.patch.object(
             threat_map_mgr.rf_client, 'request', return_value=make_response({'data': [good, bad]})
         )
-        with pytest.raises(ValidationError, match='id=broken-cat-id'):
+        with pytest.raises(ValidationError, match=validation_match('id=broken-cat-id')):
             threat_map_mgr.fetch_entity_categories(map_type='actors')
 
     def test_search_threat_actor_validation_error_names_entity(
@@ -114,7 +115,7 @@ class Test_ThreatMapMgr:
             'request_paged',
             side_effect=lambda *args, **kwargs: iter([good, bad]),  # noqa: ARG005
         )
-        with pytest.raises(ValidationError, match='id=broken-actor-id'):
+        with pytest.raises(ValidationError, match=validation_match('id=broken-actor-id')):
             threat_map_mgr.search_threat_actor(name='actor')
 
     @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10, <3.15"
 
 [options]
-exclude-newer = "2026-08-18T10:34:23.454581Z"
+exclude-newer = "2026-08-19T09:23:51.510485Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -813,7 +813,7 @@ wheels = [
 
 [[package]]
 name = "psengine"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "idna" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10, <3.15"
 
 [options]
-exclude-newer = "2026-08-12T15:52:05.155042Z"
+exclude-newer = "2026-08-18T10:34:23.454581Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -813,7 +813,7 @@ wheels = [
 
 [[package]]
 name = "psengine"
-version = "2.10.1"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "idna" },


### PR DESCRIPTION
The point of this request is to improve error handling for bulk operations. Things like `SoarMgr.soar()` now fail like this:

```
SOAREnrichedEntity validation failed at index 192 (entity.name=8.8.8.92): field 'risk.context.phishing' Input should be a valid integer
SOAREnrichedEntity validation failed at index 193 (entity.name=8.8.8.143): field 'risk.context.phishing' Input should be a valid integer
```

the error is still a validation error, but there is an added index (element of the list that failed) and optionally the entity that failed along with the field. This will hopefully make troubleshooting easier for validation errors.  The validation and the errors are also going through the whole list rather than failing at the first one. 

Compare with the way the error is handled currently:
https://recordedfuture.atlassian.net/browse/PSF-775

I have also moved the content of "Developing for PSEngine" in CONTRIBUTING.md, to make it easier for people to see. Let me know your thoughts